### PR TITLE
fix: remove useless call and correct fetch body

### DIFF
--- a/src/runtime/devtools/init.ts
+++ b/src/runtime/devtools/init.ts
@@ -81,6 +81,7 @@ export default function initServer (nuxt: Nuxt) {
           routes: routesCount
         })
       }
+      return 'ok'
     })
   })
 }

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -14,7 +14,7 @@ export default defineNuxtPlugin((nuxt) => {
       $fetch('/__hydration_ping', {
         method: 'POST',
         body: {
-          route: nuxt._route.matched[0].path
+          route: nuxt._route.matched[0]?.path ?? '/'
         }
       })
     }

--- a/src/runtime/view/TheContainer.vue
+++ b/src/runtime/view/TheContainer.vue
@@ -21,24 +21,14 @@
 <script setup lang="ts">
 // @ts-ignore tsconfig
 import { watch, ref } from 'vue'
-import { useRoute, useState } from '#imports'
+import { useState } from '#imports'
 
-const route = useRoute()
 const hydrationFailed = useState('hydration-failed', () => false)
 const state = ref(false)
 
 watch(hydrationFailed, () => {
   if (hydrationFailed.value) {
     state.value = true
-
-    // @ts-ignore tsconfig
-    $fetch('/_hydration_state', {
-      method: 'post',
-      body: {
-        route: route.fullPath,
-        hydrationFailed: true
-      }
-    })
   }
 })
 </script>


### PR DESCRIPTION
- make ` nuxt._route.matched[0].path` fallback to `/` (when using only app.vue)
- remove useless fetch call to unexisting endpoint